### PR TITLE
Add "typings" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
     "log",
     "debug",
     "state management"
-  ]
+  ],
+  "typings": "lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "$(npm bin)/rimraf dist lib",
     "build": "npm run build:lib && npm run build:umd",
-    "build:lib": "$(npm bin)/babel src --out-dir lib",
+    "build:lib": "$(npm bin)/babel src --out-dir lib && cp src/index.d.ts lib/index.d.ts",
     "build:umd": "webpack -p",
     "prepublish": "npm run clean && npm run build"
   },

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,10 @@
+declare module "mobx-logger" {
+        export interface IMobXLoggerConfig {
+                predicate?: () => boolean,
+                action?: boolean;
+                reaction?: boolean;
+                transaction?: boolean;
+                compute?: boolean;
+        }
+        export function enableLogging(config: IMobXLoggerConfig): void
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,8 @@
-declare module "mobx-logger" {
-        export interface IMobXLoggerConfig {
-                predicate?: () => boolean,
-                action?: boolean;
-                reaction?: boolean;
-                transaction?: boolean;
-                compute?: boolean;
-        }
-        export function enableLogging(config: IMobXLoggerConfig): void
+export interface IMobXLoggerConfig {
+    predicate?: () => boolean,
+    action?: boolean;
+    reaction?: boolean;
+    transaction?: boolean;
+    compute?: boolean;
 }
+export function enableLogging(config: IMobXLoggerConfig): void


### PR DESCRIPTION
This makes it possible for TypeScript compiler to look at `node_modules` for type definitions.
